### PR TITLE
switch to snmpget

### DIFF
--- a/getFanSpeed.rb
+++ b/getFanSpeed.rb
@@ -3,7 +3,7 @@ community=ARGV[0]
 fannumber=ARGV[1]
 serveraddr=ARGV[2]
 #fannumber=1
-execstr="snmpwalk -c #{community} -v 1 #{serveraddr} 1.3.6.1.4.1.2.3.51.3.1.3.2.1.3.#{fannumber}"
+execstr="snmpget -v2c -c #{community} #{serveraddr} -r 500 -t 10000000 1.3.6.1.4.1.2.3.51.3.1.3.2.1.3.#{fannumber}"
 strresult=`#{execstr}`
 fanspeed=strresult.slice(/[\d]*%/)
 if fanspeed.nil?


### PR DESCRIPTION
with snmpget you can override default timeout with -t parameter. Second thing: it's better to use -v2c which enables SNMPv2 protocol. SNMPv2 is compatibile with v1. V1 protocol caused timeouts in my environment