### PR TITLE
getFanSpeed.rb now uses makro fix #5

### DIFF
--- a/Template IBM - IMM2 SNMP.xml
+++ b/Template IBM - IMM2 SNMP.xml
@@ -244,7 +244,7 @@
                             <snmp_community/>
                             <multiplier>0</multiplier>
                             <snmp_oid/>
-                            <key>getFanSpeed.rb[&quot;public&quot;,{#SNMPINDEX},{HOST.CONN}]</key>
+                            <key>getFanSpeed.rb[{$SNMP_COMMUNITY},{#SNMPINDEX},{HOST.CONN}]</key>
                             <delay>60</delay>
                             <history>7</history>
                             <trends>365</trends>


### PR DESCRIPTION
Changed fixed SNMP community public to makro for getFanSpeed.rb